### PR TITLE
Enable semantic highlight in all the theme

### DIFF
--- a/src/themes/bright-tilted/index.mjs
+++ b/src/themes/bright-tilted/index.mjs
@@ -8,5 +8,6 @@ export default {
   type: 'vs',
   colors: mkui({ ui, code }),
   tokenColors: mktokens({ code, colours, tilts: true }),
+  semanticHighlighting: true,
   semanticTokenColors: mksemantictokens({ code, tilts: true }),
 }

--- a/src/themes/bright/index.mjs
+++ b/src/themes/bright/index.mjs
@@ -8,5 +8,6 @@ export default {
   type: 'vs',
   colors: mkui({ ui, code }),
   tokenColors: mktokens({ code, colours }),
+  semanticHighlighting: true,
   semanticTokenColors: mksemantictokens({ code, tilts: false }),
 }

--- a/src/themes/dark/index.mjs
+++ b/src/themes/dark/index.mjs
@@ -8,5 +8,6 @@ export default {
   type: 'vs-dark',
   colors: mkui({ ui, code }),
   tokenColors: mktokens({ code, colours }),
+  semanticHighlighting: true,
   semanticTokenColors: mksemantictokens({ code, tilts: false }),
 }


### PR DESCRIPTION
This PR will enable the semantic highlight in all the theme variations. Now it seems that just the `Remedy - Dark (Tilted)` has it working.
 